### PR TITLE
VIR-124 Bugfix ending up in broken auth state after refresh token expiry

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,10 +1,28 @@
 import VirkarekisterContainer from 'components/VirkarekisteriContainer';
-import msalInstance from './auth/msal-instance';
-import { MsalProvider } from '@azure/msal-react';
+import msalInstance, { validateAuthState } from './auth/msal-instance';
+import { useEffect, useState } from 'react';
 
-const App = () => (
-  <MsalProvider instance={msalInstance}>
-    <VirkarekisterContainer />
-  </MsalProvider>
-);
+const App = () => {
+  const [appIsReady, setAppIsReady] = useState(false);
+
+  useEffect(() => {
+    const init = async () => {
+      if (!(await validateAuthState()))
+        // if the auth state is "broken" (refresh token has expired or there is some unknown unexpected error),
+        // silently "log out" (more accurately, tell MSAL that it needs to clear its state) the user
+        await msalInstance.logoutRedirect({
+          account: msalInstance.getActiveAccount(),
+          onRedirectNavigate: () => false,
+        });
+
+      setAppIsReady(true);
+    };
+
+    init().catch(console.error);
+  }, []);
+
+  if (!appIsReady) return null;
+
+  return <VirkarekisterContainer />;
+};
 export default App;

--- a/frontend/src/auth/msal-instance.ts
+++ b/frontend/src/auth/msal-instance.ts
@@ -37,15 +37,13 @@ export const setupMsalEventListeners = (store: AppStore) => {
     if (event.eventType === EventType.ACQUIRE_TOKEN_FAILURE) {
       const error = event.error as AuthError;
 
-      // if refresh token has expired, log out the user
+      // if the refresh token has expired, log out the user
       // a manual re-login is required
-      if (error.name === 'InteractionRequiredAuthError') {
+      if (error.name === 'InteractionRequiredAuthError')
         await msalInstance.logoutRedirect({
           account: msalInstance.getActiveAccount(),
           onRedirectNavigate: () => false,
         });
-        store.dispatch(clearAuthState());
-      }
     }
 
     if (event.eventType === EventType.LOGOUT_SUCCESS) {

--- a/frontend/src/auth/msal-instance.ts
+++ b/frontend/src/auth/msal-instance.ts
@@ -1,6 +1,6 @@
-import type { AuthenticationResult, EventMessage } from '@azure/msal-browser';
+import type { AuthenticationResult, AuthError, EventMessage } from '@azure/msal-browser';
 import { EventType, PublicClientApplication } from '@azure/msal-browser';
-import { msalConfig } from './auth-config';
+import { loginRequest, msalConfig } from './auth-config';
 import type { AppStore } from 'redux/store';
 import { clearAuthState, updateAuthState } from 'redux/slices/auth-slice';
 
@@ -18,7 +18,7 @@ msalInstance.enableAccountStorageEvents();
 // kind of a hack, but we have to somehow interlink the Redux store with the MSAL instance
 // and this is a convenient place
 export const setupMsalEventListeners = (store: AppStore) => {
-  msalInstance.addEventCallback((event: EventMessage) => {
+  msalInstance.addEventCallback(async (event: EventMessage) => {
     if (event.eventType === EventType.LOGIN_SUCCESS) {
       const payload = event.payload as AuthenticationResult;
 
@@ -28,15 +28,57 @@ export const setupMsalEventListeners = (store: AppStore) => {
       }
     }
 
+    // interlink the Redux store with the MSAL instance
     if (event.eventType === EventType.ACQUIRE_TOKEN_SUCCESS) {
       const payload = event.payload as AuthenticationResult;
       if (payload.account) store.dispatch(updateAuthState(payload));
+    }
+
+    if (event.eventType === EventType.ACQUIRE_TOKEN_FAILURE) {
+      const error = event.error as AuthError;
+
+      // if refresh token has expired, log out the user
+      // a manual re-login is required
+      if (error.name === 'InteractionRequiredAuthError') {
+        await msalInstance.logoutRedirect({
+          account: msalInstance.getActiveAccount(),
+          onRedirectNavigate: () => false,
+        });
+        store.dispatch(clearAuthState());
+      }
     }
 
     if (event.eventType === EventType.LOGOUT_SUCCESS) {
       store.dispatch(clearAuthState());
     }
   });
+};
+
+/**
+ * Helper function to acquire an access token silently.
+ */
+export const acquireAccessToken = async () =>
+  (
+    await msalInstance.acquireTokenSilent({
+      scopes: loginRequest.scopes,
+      account: msalInstance.getActiveAccount()!,
+    })
+  ).accessToken;
+
+/**
+ * Helper function to validate the authentication state.
+ * Checks that if there is an active account, we're able to retrieve access tokens if needed.
+ * If, e.g., the auth state has been sitting stale for a while in the browser's storage, the refresh
+ * token might have expired and therefore the whole auth state is invalid.
+ */
+export const validateAuthState = async () => {
+  try {
+    if (msalInstance.getActiveAccount()) await acquireAccessToken();
+    return true;
+  } catch (error) {
+    console.error('validateAuthState error', error);
+    return false;
+  }
 };
 
 export default msalInstance;

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -7,6 +7,8 @@ import { store } from './redux/store';
 import { createTheme, StyledEngineProvider, ThemeProvider } from '@mui/material/styles';
 import { CssBaseline } from '@mui/material';
 import './react-i18n.config';
+import msalInstance, { setupMsalEventListeners } from './auth/msal-instance';
+import { MsalProvider } from '@azure/msal-react';
 
 const rootElement = document.getElementById('root');
 const root = createRoot(rootElement!);
@@ -36,13 +38,18 @@ const theme = createTheme({
   },
 });
 
+await msalInstance.initialize();
+setupMsalEventListeners(store);
+
 root.render(
   <StrictMode>
     <StyledEngineProvider injectFirst>
       <ThemeProvider theme={theme}>
         <Provider store={store}>
           <CssBaseline />
-          <App />
+          <MsalProvider instance={msalInstance}>
+            <App />
+          </MsalProvider>
         </Provider>
       </ThemeProvider>
     </StyledEngineProvider>

--- a/frontend/src/redux/store.ts
+++ b/frontend/src/redux/store.ts
@@ -5,7 +5,6 @@ import { positionSlice } from './slices/position-slice';
 import positionNameSlice from './slices/position-name-slice';
 import organizationTreeSlice from './slices/organization-tree-slice';
 import { authSlice } from './slices/auth-slice';
-import { setupMsalEventListeners } from 'auth/msal-instance';
 
 const rootReducer = combineSlices(positionSlice, positionNameSlice, organizationTreeSlice, authSlice);
 
@@ -42,7 +41,6 @@ export const makeStore = (preloadedState?: Partial<RootState>) => {
 };
 
 export const store = makeStore();
-setupMsalEventListeners(store);
 
 // Infer the type of `store`
 export type AppStore = typeof store;

--- a/frontend/src/services/api-client.ts
+++ b/frontend/src/services/api-client.ts
@@ -1,6 +1,5 @@
 import axios from 'axios';
-import msalInstance from 'auth/msal-instance';
-import { loginRequest } from 'auth/auth-config';
+import { acquireAccessToken } from 'auth/msal-instance';
 
 const baseUrl = import.meta.env.VITE_API_BASE_URL;
 
@@ -9,10 +8,7 @@ const apiClient = axios.create({
 });
 
 apiClient.interceptors.request.use(async (config) => {
-  const { accessToken } = await msalInstance.acquireTokenSilent({
-    scopes: loginRequest.scopes,
-    account: msalInstance.getActiveAccount()!,
-  });
+  const accessToken = await acquireAccessToken();
   config.headers.Authorization = `Bearer ${accessToken}`;
 
   if (import.meta.env.VITE_AZURE_FUNCTION_KEY) config.headers.X_FUNCTIONS_KEY = import.meta.env.VITE_AZURE_FUNCTION_KEY;


### PR DESCRIPTION
The frontend could end up in a broken state, where msal is set an active account, but it doesn't know that the refresh token has expired. If refresh token has expired, you have to manually re-login. So basically the active account is useless.  
And since with msal-react the conditional rendering of components is based on "is there an active account", the frontend would still render the views that require authentication and attempt to get an access token to call the backend. But of course, it would fail.

* This should be fixed now, so that on startup of the app, we check if we have a valid auth state (check if we're able to refresh our access token). And if we're unable to do that, we clear the currently logged in account.
* Also some slight refactoring and adding of comments