### PR TITLE
(#157) Fix state of isTeacher and other bugs

### DIFF
--- a/backend/Virkarekisteri/src/Functions/Positions/CreatePositionsFromCsv.cs
+++ b/backend/Virkarekisteri/src/Functions/Positions/CreatePositionsFromCsv.cs
@@ -130,6 +130,16 @@ public class CreatePositionsFromCsv(
                     position.EndedAt = string.IsNullOrWhiteSpace(values[5])
                         ? (DateTime?)null
                         : DateTime.Parse(values[5], CultureInfo.InvariantCulture);
+                    // Set VacancyStatus = 1 if no end date or end date is in the future
+                    if (!position.EndedAt.HasValue || position.EndedAt.Value.Date > DateTime.Now.Date)
+                    {
+                        position.VacancyStatus = 1; // 1 = Established
+                    }
+                    else
+                    {
+                        position.VacancyStatus = 0; // 0 = Abolished
+                    }
+
                     position.EndingDecisionNumber = string.IsNullOrWhiteSpace(values[6]) ? null : values[6];
                     position.VacancySize = string.IsNullOrWhiteSpace(values[7])
                         ? (decimal?)null

--- a/backend/Virkarekisteri/src/Models/Position.cs
+++ b/backend/Virkarekisteri/src/Models/Position.cs
@@ -86,4 +86,22 @@ public class Position
 
     [NotMapped]
     public List<Guid> SubjectIds { get; set; } = new List<Guid>();
+
+    [NotMapped]
+    public string? EmployeeName { get; set; }
+
+    [NotMapped]
+    public string? EmployeeStartDate { get; set; }
+
+    [NotMapped]
+    public string? EmployeeEndDate { get; set; }
+
+    [NotMapped]
+    public string? ReplacementName { get; set; }
+
+    [NotMapped]
+    public string? ReplacementStartDate { get; set; }
+
+    [NotMapped]
+    public string? ReplacementEndDate { get; set; }
 }

--- a/backend/Virkarekisteri/src/Models/Position.cs
+++ b/backend/Virkarekisteri/src/Models/Position.cs
@@ -82,7 +82,7 @@ public class Position
 
     [Required]
     [Column("OnOpettaja")]
-    public bool IsTeacher { get; set; } = false;
+    public bool IsTeacher { get; set; }
 
     [NotMapped]
     public List<Guid> SubjectIds { get; set; } = new List<Guid>();

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -60,6 +60,7 @@
     "created_at": "Created at",
     "ended_at": "Position abolition date",
     "creation_decision_number": "Creation decision number",
+    "ending_decision_number": "End position decision number",
     "placement_location": "Placement location",
     "type": "Type",
     "vacancy_number": "Vacancy number",

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -58,6 +58,7 @@
   },
   "table": {
     "created_at": "Created at",
+    "ended_at": "Position abolition date",
     "creation_decision_number": "Creation decision number",
     "placement_location": "Placement location",
     "type": "Type",

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -58,6 +58,7 @@
   },
   "table": {
     "created_at": "Perustamisajankohta",
+    "ended_at": "Viran lakkautus päivämäärä",
     "creation_decision_number": "Päätösnumero",
     "type": "Laji",
     "vacancy_number": "Vakanssinumero",

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -60,6 +60,7 @@
     "created_at": "Perustamisajankohta",
     "ended_at": "Viran lakkautus päivämäärä",
     "creation_decision_number": "Päätösnumero",
+    "ending_decision_number": "Lakkautus päätösnumero",
     "type": "Laji",
     "vacancy_number": "Vakanssinumero",
     "vacancy_size": "Vakanssikoko",

--- a/frontend/public/locales/sv/translation.json
+++ b/frontend/public/locales/sv/translation.json
@@ -58,6 +58,7 @@
   },
   "table": {
     "created_at": "",
+    "ended_at": "",
     "creation_decision_number": "",
     "placement_location": "",
     "type": "",

--- a/frontend/public/locales/sv/translation.json
+++ b/frontend/public/locales/sv/translation.json
@@ -60,6 +60,7 @@
     "created_at": "",
     "ended_at": "",
     "creation_decision_number": "",
+    "ending_decision_number": "",
     "placement_location": "",
     "type": "",
     "vacancy_number": "",

--- a/frontend/src/components/Modal/MassChangesModal.tsx
+++ b/frontend/src/components/Modal/MassChangesModal.tsx
@@ -65,6 +65,7 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
           details: position.details,
           type: position.type,
           decisionNumber: values.decisionNumber,
+          isTeacher: position.isTeacher,
         };
 
         // Override the specific field with the new value

--- a/frontend/src/components/Table/VirkarekisteriTable.tsx
+++ b/frontend/src/components/Table/VirkarekisteriTable.tsx
@@ -814,7 +814,7 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
             setPage(model.page);
             setRowsPerPage(model.pageSize);
           }}
-          pageSizeOptions={[10, 30, 50, 100, 300, 500, 1000]}
+          pageSizeOptions={[10, 30, 50, 100]}
           checkboxSelection
           onRowSelectionModelChange={(newSelection) => {
             const selection = newSelection as string[];

--- a/frontend/src/components/Table/VirkarekisteriTable.tsx
+++ b/frontend/src/components/Table/VirkarekisteriTable.tsx
@@ -479,6 +479,12 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
       },
     },
     {
+      field: 'endingDecisionNumber',
+      headerName: t('table.ending_decision_number'),
+      flex: 1,
+      sortable: true,
+    },
+    {
       field: 'employeeName',
       headerName: t('table.employee_name'),
       flex: 1,

--- a/frontend/src/components/Table/VirkarekisteriTable.tsx
+++ b/frontend/src/components/Table/VirkarekisteriTable.tsx
@@ -469,6 +469,16 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
       },
     },
     {
+      field: 'endedAt',
+      headerName: t('table.ended_at'),
+      flex: 1,
+      sortable: true,
+      valueFormatter: (params: string) => {
+        if (!params) return '';
+        return format(new Date(params), 'dd.MM.yyyy');
+      },
+    },
+    {
       field: 'employeeName',
       headerName: t('table.employee_name'),
       flex: 1,


### PR DESCRIPTION
(#157) (#156) Fix state of isTeacher and CSV import issue
* Remove false initializer since bool defaults to false anyway
* Fix bug with mass changes which made change to isTeacher affecting
  history of changes
* Fix to remove rows per page >100 as those are not supported in free
  MUI datagrid
* Added endedAt to the datagrid and translations for it
* Frontend interface needed fields and backend did not have these which caused
  errors during building and usage at the production
* Added ending decisiong number to the datagrid with translations
* Fixed vacancy status being abolished after CSV import