### PR TITLE
(#135) Selection of authorized costcentre for position

### DIFF
--- a/frontend/src/components/AdminPanel/CostcentreAdmin.tsx
+++ b/frontend/src/components/AdminPanel/CostcentreAdmin.tsx
@@ -23,6 +23,7 @@ import { RequiresEditRole } from 'components/role-guards';
 import CostcentreDetails from 'components/Details/CostcentreDetails';
 import { format } from 'date-fns';
 import CreateCostcentreModal from 'components/Modal/CreateCostcentreModal';
+import { checkCostCentreActiveStatus } from 'utils/checkCostCentreActiveStatus';
 
 const CostcentreAdmin = () => {
   const { t } = useTranslation();
@@ -297,7 +298,9 @@ const CostcentreAdmin = () => {
                   onClick={() => handleRowToggle(row)}
                 >
                   <TableCell sx={{ color: 'black', fontSize: '1rem' }}>{row.number}</TableCell>
-                  <TableCell sx={{ color: 'black', fontSize: '1rem' }}>{row.name}</TableCell>
+                  <TableCell sx={{ color: 'black', fontSize: '1rem' }}>
+                    {checkCostCentreActiveStatus(row, t('create_position.not_active_suffix'))}
+                  </TableCell>
                   <TableCell sx={{ color: 'black', fontSize: '1rem' }}>
                     {row.validFrom ? format(new Date(row.validFrom), 'd.M.yyyy') : ''}
                   </TableCell>

--- a/frontend/src/components/Modal/CreateVirkaModal.tsx
+++ b/frontend/src/components/Modal/CreateVirkaModal.tsx
@@ -105,6 +105,16 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
     return undefined;
   };
 
+  const isCostcentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+  
+    const validFrom = costCentre.validFrom ? new Date(costCentre.validFrom) : null;
+    const validUntil = costCentre.validUntil ? new Date(costCentre.validUntil) : null;
+  
+    return (!validFrom || validFrom <= today) && (!validUntil || validUntil >= today);
+  };
+
   useEffect(() => {
     if (!open) {
       setIsTeacherPosition(false);
@@ -297,7 +307,7 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
                       {({ input }) => (
                         <Autocomplete
                           {...input}
-                          options={costcentres}
+                          options={costcentres.filter(isCostcentreActive)}
                           loading={costcentresLoading}
                           getOptionLabel={(option) =>
                             option

--- a/frontend/src/components/Modal/CreateVirkaModal.tsx
+++ b/frontend/src/components/Modal/CreateVirkaModal.tsx
@@ -108,10 +108,10 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
   const isCostcentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-  
+
     const validFrom = costCentre.validFrom ? new Date(costCentre.validFrom) : null;
     const validUntil = costCentre.validUntil ? new Date(costCentre.validUntil) : null;
-  
+
     return (!validFrom || validFrom <= today) && (!validUntil || validUntil >= today);
   };
 

--- a/frontend/src/components/Modal/MassChangesModal.tsx
+++ b/frontend/src/components/Modal/MassChangesModal.tsx
@@ -44,10 +44,7 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
   
     const validFrom = costCentre.validFrom ? new Date(costCentre.validFrom) : null;
     const validUntil = costCentre.validUntil ? new Date(costCentre.validUntil) : null;
-  
-    if (validFrom) validFrom.setHours(0, 0, 0, 0);
-    if (validUntil) validUntil.setHours(0, 0, 0, 0);
-  
+
     return (!validFrom || validFrom <= today) && (!validUntil || validUntil >= today);
   };
   

--- a/frontend/src/components/Modal/MassChangesModal.tsx
+++ b/frontend/src/components/Modal/MassChangesModal.tsx
@@ -38,6 +38,20 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
     open ? undefined : skipToken,
   );
 
+  const isCostcentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+  
+    const validFrom = costCentre.validFrom ? new Date(costCentre.validFrom) : null;
+    const validUntil = costCentre.validUntil ? new Date(costCentre.validUntil) : null;
+  
+    if (validFrom) validFrom.setHours(0, 0, 0, 0);
+    if (validUntil) validUntil.setHours(0, 0, 0, 0);
+  
+    return (!validFrom || validFrom <= today) && (!validUntil || validUntil >= today);
+  };
+  
+
   const [updatePosition] = useUpdatePositionMutation();
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
 
@@ -177,7 +191,9 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
                                     id: tree.id,
                                     label: `${tree.name}`,
                                   }))
-                                : costcentres.map((tree) => ({
+                                : costcentres
+                                  .filter(isCostcentreActive)
+                                  .map((tree) => ({
                                     id: tree.id,
                                     label: `${tree.number} ${tree.name}`,
                                   }))

--- a/frontend/src/components/Modal/MassChangesModal.tsx
+++ b/frontend/src/components/Modal/MassChangesModal.tsx
@@ -41,16 +41,15 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
   const isCostcentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-  
+
     const validFrom = costCentre.validFrom ? new Date(costCentre.validFrom) : null;
     const validUntil = costCentre.validUntil ? new Date(costCentre.validUntil) : null;
-  
+
     if (validFrom) validFrom.setHours(0, 0, 0, 0);
     if (validUntil) validUntil.setHours(0, 0, 0, 0);
-  
+
     return (!validFrom || validFrom <= today) && (!validUntil || validUntil >= today);
   };
-  
 
   const [updatePosition] = useUpdatePositionMutation();
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -191,9 +190,7 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
                                     id: tree.id,
                                     label: `${tree.name}`,
                                   }))
-                                : costcentres
-                                  .filter(isCostcentreActive)
-                                  .map((tree) => ({
+                                : costcentres.filter(isCostcentreActive).map((tree) => ({
                                     id: tree.id,
                                     label: `${tree.number} ${tree.name}`,
                                   }))

--- a/frontend/src/components/Modal/ModifyVirkaModal.tsx
+++ b/frontend/src/components/Modal/ModifyVirkaModal.tsx
@@ -145,10 +145,10 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
   const isCostCentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
-  
+
     const validFrom = costCentre.validFrom ? new Date(costCentre.validFrom) : null;
     const validUntil = costCentre.validUntil ? new Date(costCentre.validUntil) : null;
-  
+
     return (!validFrom || validFrom <= today) && (!validUntil || validUntil >= today);
   };
 

--- a/frontend/src/components/Modal/ModifyVirkaModal.tsx
+++ b/frontend/src/components/Modal/ModifyVirkaModal.tsx
@@ -142,6 +142,16 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
     return undefined;
   };
 
+  const isCostCentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+  
+    const validFrom = costCentre.validFrom ? new Date(costCentre.validFrom) : null;
+    const validUntil = costCentre.validUntil ? new Date(costCentre.validUntil) : null;
+  
+    return (!validFrom || validFrom <= today) && (!validUntil || validUntil >= today);
+  };
+
   const onSubmit = async (values: FormValues) => {
     if (!position.id) {
       return;
@@ -287,7 +297,7 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
                     <Field name="costcentre">
                       {({ input }) => (
                         <Autocomplete
-                          options={costcentres}
+                          options={costcentres.filter(isCostCentreActive)}
                           getOptionLabel={(option) =>
                             `${option.number} ${checkCostCentreActiveStatus(option, t('edit_position.not_active_suffix'))}`
                           }

--- a/frontend/src/utils/checkCostCentreActiveStatus.ts
+++ b/frontend/src/utils/checkCostCentreActiveStatus.ts
@@ -2,6 +2,7 @@ import type { Costcentre } from 'models/Costcentre';
 
 export const checkCostCentreActiveStatus = (costCentre: Costcentre | undefined, notActiveSuffix: string): string => {
   const today = new Date();
+  today.setHours(0, 0, 0, 0);
 
   if (!costCentre) {
     return '';


### PR DESCRIPTION
- Only show active costcentres when creating a new position or modifying one (or multiple with mass changes)
- Show (not active) suffix in costcentre control panel for non-active costcentres

![image](https://github.com/user-attachments/assets/379a9799-77aa-4145-b19d-9c4776255e03)
