### PR TITLE
Task/170 frontend improvements

### DIFF
--- a/database/scripts/Inserts/PositionNames.sql
+++ b/database/scripts/Inserts/PositionNames.sql
@@ -145,7 +145,7 @@ VALUES
     ('kouluvalmentaja', NULL, NULL),
     ('kuljetuskoordinaattori', NULL, NULL),
     ('kuljetussuunnittelija', NULL, NULL),
-    ('kulttuurikasvatussuunnitelmakoordinaatto', NULL, NULL),
+    ('kulttuurikasvatussuunnitelmakoordinaattori', NULL, NULL),
     ('kulttuuriohjaaja', NULL, NULL),
     ('kulttuuripalvelupäällikkö', NULL, NULL),
     ('kulttuuritoimen johtaja', NULL, NULL),

--- a/frontend/src/components/AdminPanel/CostcentreAdmin.tsx
+++ b/frontend/src/components/AdminPanel/CostcentreAdmin.tsx
@@ -42,7 +42,16 @@ const CostcentreAdmin = () => {
   const isLoading = costcentresLoading;
 
   useEffect(() => {
-    setFilteredCostcentres(costcentres);
+    if (costcentres.length > 0) {
+      const sortedByNumber = [...costcentres].sort((a, b) => {
+        const numA = a.number ?? '';
+        const numB = b.number ?? '';
+        return numA < numB ? -1 : numA > numB ? 1 : 0;
+      });
+      setFilteredCostcentres(sortedByNumber);
+    } else {
+      setFilteredCostcentres([]);
+    }
   }, [costcentres]);
 
   const paginatedCostcentres = filteredCostcentres.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
@@ -130,7 +139,13 @@ const CostcentreAdmin = () => {
         setFilteredCostcentres(sortedData);
         return { key, direction: 'desc' };
       } else {
-        setFilteredCostcentres(costcentres);
+        const defaultSorted = [...costcentres].sort((a, b) => {
+          const numA = a.number ?? '';
+          const numB = b.number ?? '';
+          return numA < numB ? -1 : numA > numB ? 1 : 0;
+        });
+        
+        setFilteredCostcentres(defaultSorted);
         return null;
       }
     });

--- a/frontend/src/components/AdminPanel/CostcentreAdmin.tsx
+++ b/frontend/src/components/AdminPanel/CostcentreAdmin.tsx
@@ -55,7 +55,7 @@ const CostcentreAdmin = () => {
       const numB = b.number ?? '';
       return numA < numB ? -1 : numA > numB ? 1 : 0;
     });
-  }
+  };
 
   const paginatedCostcentres = filteredCostcentres.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
 

--- a/frontend/src/components/AdminPanel/CostcentreAdmin.tsx
+++ b/frontend/src/components/AdminPanel/CostcentreAdmin.tsx
@@ -43,16 +43,19 @@ const CostcentreAdmin = () => {
 
   useEffect(() => {
     if (costcentres.length > 0) {
-      const sortedByNumber = [...costcentres].sort((a, b) => {
-        const numA = a.number ?? '';
-        const numB = b.number ?? '';
-        return numA < numB ? -1 : numA > numB ? 1 : 0;
-      });
-      setFilteredCostcentres(sortedByNumber);
+      setFilteredCostcentres(applyDefaultSorting(costcentres));
     } else {
       setFilteredCostcentres([]);
     }
   }, [costcentres]);
+
+  const applyDefaultSorting = (data: Costcentre[]) => {
+    return [...data].sort((a, b) => {
+      const numA = a.number ?? '';
+      const numB = b.number ?? '';
+      return numA < numB ? -1 : numA > numB ? 1 : 0;
+    });
+  }
 
   const paginatedCostcentres = filteredCostcentres.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage);
 
@@ -96,14 +99,14 @@ const CostcentreAdmin = () => {
       return matchesName && matchesActive;
     });
 
-    setFilteredCostcentres(filtered);
+    setFilteredCostcentres(applyDefaultSorting(filtered));
     setPage(0);
   };
 
   const handleSearchReset = () => {
     setSearchCostcentreName('');
     setSearchActive(false);
-    setFilteredCostcentres(costcentres);
+    setFilteredCostcentres(applyDefaultSorting(costcentres));
     setPage(0);
   };
 
@@ -139,13 +142,7 @@ const CostcentreAdmin = () => {
         setFilteredCostcentres(sortedData);
         return { key, direction: 'desc' };
       } else {
-        const defaultSorted = [...costcentres].sort((a, b) => {
-          const numA = a.number ?? '';
-          const numB = b.number ?? '';
-          return numA < numB ? -1 : numA > numB ? 1 : 0;
-        });
-        
-        setFilteredCostcentres(defaultSorted);
+        setFilteredCostcentres(applyDefaultSorting(filteredCostcentres));
         return null;
       }
     });

--- a/frontend/src/components/AdminPanel/SubjectAdmin.tsx
+++ b/frontend/src/components/AdminPanel/SubjectAdmin.tsx
@@ -26,7 +26,8 @@ import EditSubjectModal from 'components/Modal/EditSubjectModal';
 import ActivityLight from 'components/Components/ActivityLight';
 
 const SubjectAdmin = () => {
-  const { t } = useTranslation();
+  const { t, i18n } = useTranslation();
+  const locale = i18n.language || 'fi';
 
   const [expandedRow, setExpandedRow] = useState<TeacherSubject | null>(null);
   const [filteredSubjects, setFilteredTeacherSubjects] = useState<TeacherSubject[]>([]);
@@ -41,7 +42,14 @@ const SubjectAdmin = () => {
   const isLoading = teacherSubjectsLoading;
 
   useEffect(() => {
-    setFilteredTeacherSubjects(teacherSubjects);
+    if (teacherSubjects.length > 0) {
+      const sortedByName = [...teacherSubjects].sort((a, b) => {
+        return a.subjectName.localeCompare(b.subjectName, locale);
+      });
+      setFilteredTeacherSubjects(sortedByName);
+    } else {
+      setFilteredTeacherSubjects([]);
+    }
   }, [teacherSubjects]);
 
   const [createModalOpen, setCreateModalOpen] = useState(false);
@@ -88,7 +96,7 @@ const SubjectAdmin = () => {
           const aName = a['subjectName'] as string;
           const bName = b['subjectName'] as string;
 
-          return aName.localeCompare(bName);
+          return aName.localeCompare(bName, locale);
         } else {
           // primary sort by active/inactive
           if (sortConfig.direction == 'asc') return aActive ? 1 : -1;
@@ -101,7 +109,7 @@ const SubjectAdmin = () => {
       const aValue = a[sortConfig.key] as string;
       const bValue = b[sortConfig.key] as string;
 
-      return sortConfig.direction === 'asc' ? aValue.localeCompare(bValue) : bValue.localeCompare(aValue);
+      return sortConfig.direction === 'asc' ? aValue.localeCompare(bValue, locale) : bValue.localeCompare(aValue, locale);
     });
   }, [filteredSubjects, sortConfig]);
 
@@ -110,6 +118,7 @@ const SubjectAdmin = () => {
 
   const handleChangePage = (_: unknown, newPage: number) => {
     setPage(newPage);
+    setExpandedRow(null);
   };
 
   const handleChangeRowsPerPage = (event: React.ChangeEvent<HTMLInputElement>) => {

--- a/frontend/src/components/AdminPanel/SubjectAdmin.tsx
+++ b/frontend/src/components/AdminPanel/SubjectAdmin.tsx
@@ -26,8 +26,7 @@ import EditSubjectModal from 'components/Modal/EditSubjectModal';
 import ActivityLight from 'components/Components/ActivityLight';
 
 const SubjectAdmin = () => {
-  const { t, i18n } = useTranslation();
-  const locale = i18n.language || 'fi';
+  const { t } = useTranslation();
 
   const [expandedRow, setExpandedRow] = useState<TeacherSubject | null>(null);
   const [filteredSubjects, setFilteredTeacherSubjects] = useState<TeacherSubject[]>([]);
@@ -44,7 +43,7 @@ const SubjectAdmin = () => {
   useEffect(() => {
     if (teacherSubjects.length > 0) {
       const sortedByName = [...teacherSubjects].sort((a, b) => {
-        return a.subjectName.localeCompare(b.subjectName, locale);
+        return a.subjectName.localeCompare(b.subjectName, 'fi');
       });
       setFilteredTeacherSubjects(sortedByName);
     } else {
@@ -96,7 +95,7 @@ const SubjectAdmin = () => {
           const aName = a['subjectName'] as string;
           const bName = b['subjectName'] as string;
 
-          return aName.localeCompare(bName, locale);
+          return aName.localeCompare(bName, 'fi');
         } else {
           // primary sort by active/inactive
           if (sortConfig.direction == 'asc') return aActive ? 1 : -1;
@@ -109,7 +108,7 @@ const SubjectAdmin = () => {
       const aValue = a[sortConfig.key] as string;
       const bValue = b[sortConfig.key] as string;
 
-      return sortConfig.direction === 'asc' ? aValue.localeCompare(bValue, locale) : bValue.localeCompare(aValue, locale);
+      return sortConfig.direction === 'asc' ? aValue.localeCompare(bValue, 'fi') : bValue.localeCompare(aValue, 'fi');
     });
   }, [filteredSubjects, sortConfig]);
 

--- a/frontend/src/components/AdminPanel/SubjectAdmin.tsx
+++ b/frontend/src/components/AdminPanel/SubjectAdmin.tsx
@@ -42,14 +42,17 @@ const SubjectAdmin = () => {
 
   useEffect(() => {
     if (teacherSubjects.length > 0) {
-      const sortedByName = [...teacherSubjects].sort((a, b) => {
-        return a.subjectName.localeCompare(b.subjectName, 'fi');
-      });
-      setFilteredTeacherSubjects(sortedByName);
+      setFilteredTeacherSubjects(applyDefaultSorting(teacherSubjects));
     } else {
       setFilteredTeacherSubjects([]);
     }
   }, [teacherSubjects]);
+
+  const applyDefaultSorting = (data: TeacherSubject[]) => {
+    return [...data].sort((a, b) => {
+      return a.subjectName.localeCompare(b.subjectName, 'fi');
+    });
+  }
 
   const [createModalOpen, setCreateModalOpen] = useState(false);
 
@@ -134,14 +137,14 @@ const SubjectAdmin = () => {
       const matchesActive = showOnlyActiveSubjects ? s.active === true : true;
       return matchesName && matchesActive;
     });
-    setFilteredTeacherSubjects(filtered);
+    setFilteredTeacherSubjects(applyDefaultSorting(filtered));
     setPage(0);
   };
 
   const handleResetSearch = () => {
     setSearchSubjectName('');
     setShowOnlyActiveSubjects(false);
-    setFilteredTeacherSubjects(teacherSubjects);
+    setFilteredTeacherSubjects(applyDefaultSorting(teacherSubjects));
     setPage(0);
   };
 

--- a/frontend/src/components/AdminPanel/SubjectAdmin.tsx
+++ b/frontend/src/components/AdminPanel/SubjectAdmin.tsx
@@ -52,7 +52,7 @@ const SubjectAdmin = () => {
     return [...data].sort((a, b) => {
       return a.subjectName.localeCompare(b.subjectName, 'fi');
     });
-  }
+  };
 
   const [createModalOpen, setCreateModalOpen] = useState(false);
 
@@ -131,8 +131,8 @@ const SubjectAdmin = () => {
   // Search logic
   const handleSearch = () => {
     const filtered = teacherSubjects.filter((s) => {
-      const matchesName = searchSubjectName 
-        ? s['subjectName'].toLowerCase().includes(searchSubjectName.toLowerCase()) 
+      const matchesName = searchSubjectName
+        ? s['subjectName'].toLowerCase().includes(searchSubjectName.toLowerCase())
         : true;
       const matchesActive = showOnlyActiveSubjects ? s.active === true : true;
       return matchesName && matchesActive;

--- a/frontend/src/components/AdminPanel/SubjectAdmin.tsx
+++ b/frontend/src/components/AdminPanel/SubjectAdmin.tsx
@@ -120,7 +120,9 @@ const SubjectAdmin = () => {
   // Search logic
   const handleSearch = () => {
     const filtered = teacherSubjects.filter((s) => {
-      const matchesName = searchSubjectName ? s['subjectName'].includes(searchSubjectName) : true;
+      const matchesName = searchSubjectName 
+        ? s['subjectName'].toLowerCase().includes(searchSubjectName.toLowerCase()) 
+        : true;
       const matchesActive = showOnlyActiveSubjects ? s.active === true : true;
       return matchesName && matchesActive;
     });

--- a/frontend/src/components/Modal/CreateVirkaModal.tsx
+++ b/frontend/src/components/Modal/CreateVirkaModal.tsx
@@ -307,9 +307,7 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
                       {({ input }) => (
                         <Autocomplete
                           {...input}
-                          options={[...costcentres]
-                            .filter(isCostcentreActive)
-                            .sort((a, b) => a.number - b.number)}
+                          options={[...costcentres].filter(isCostcentreActive).sort((a, b) => a.number - b.number)}
                           loading={costcentresLoading}
                           getOptionLabel={(option) =>
                             option

--- a/frontend/src/components/Modal/CreateVirkaModal.tsx
+++ b/frontend/src/components/Modal/CreateVirkaModal.tsx
@@ -198,7 +198,7 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
                     <Field name="positionNameId">
                       {({ input }) => (
                         <Autocomplete
-                          options={positionNames}
+                          options={[...positionNames].sort((a, b) => a.name.localeCompare(b.name, 'fi'))}
                           loading={positionNamesLoading}
                           getOptionLabel={(option) => option.name}
                           value={input.value || null}
@@ -307,7 +307,9 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
                       {({ input }) => (
                         <Autocomplete
                           {...input}
-                          options={costcentres.filter(isCostcentreActive)}
+                          options={[...costcentres]
+                            .filter(isCostcentreActive)
+                            .sort((a, b) => a.number - b.number)}
                           loading={costcentresLoading}
                           getOptionLabel={(option) =>
                             option

--- a/frontend/src/components/Modal/MassChangesModal.tsx
+++ b/frontend/src/components/Modal/MassChangesModal.tsx
@@ -187,14 +187,19 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
                             {...input}
                             options={
                               selectedOption === 'positionNameId'
-                                ? positionNames.map((tree) => ({
-                                    id: tree.id,
-                                    label: `${tree.name}`,
-                                  }))
-                                : costcentres.filter(isCostcentreActive).map((tree) => ({
-                                    id: tree.id,
-                                    label: `${tree.number} ${tree.name}`,
-                                  }))
+                                ? [...positionNames]
+                                    .sort((a, b) => a.name.localeCompare(b.name, 'fi'))
+                                    .map((tree) => ({
+                                      id: tree.id,
+                                      label: `${tree.name}`,
+                                    }))
+                                : [...costcentres]
+                                    .filter(isCostcentreActive)
+                                    .sort((a, b) => a.number - b.number)
+                                    .map((tree) => ({
+                                      id: tree.id,
+                                      label: `${tree.number} ${tree.name}`,
+                                    }))
                             }
                             getOptionLabel={(option) => (typeof option === 'string' ? option : option.label || '')}
                             loading={selectedOption === 'positionNameId' ? positionNamesLoading : costcentresLoading}

--- a/frontend/src/components/Modal/ModifyVirkaModal.tsx
+++ b/frontend/src/components/Modal/ModifyVirkaModal.tsx
@@ -297,9 +297,7 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
                     <Field name="costcentre">
                       {({ input }) => (
                         <Autocomplete
-                          options={[...costcentres]
-                            .filter(isCostcentreActive)
-                            .sort((a, b) => a.number - b.number)}
+                          options={[...costcentres].filter(isCostcentreActive).sort((a, b) => a.number - b.number)}
                           getOptionLabel={(option) =>
                             `${option.number} ${checkCostCentreActiveStatus(option, t('edit_position.not_active_suffix'))}`
                           }

--- a/frontend/src/components/Modal/ModifyVirkaModal.tsx
+++ b/frontend/src/components/Modal/ModifyVirkaModal.tsx
@@ -142,7 +142,7 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
     return undefined;
   };
 
-  const isCostCentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
+  const isCostcentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
     const today = new Date();
     today.setHours(0, 0, 0, 0);
 
@@ -261,7 +261,7 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
                       <Field name="positionName">
                         {({ input }) => (
                           <Autocomplete
-                            options={positionNames}
+                            options={[...positionNames].sort((a, b) => a.name.localeCompare(b.name, 'fi'))}
                             getOptionLabel={(option) => `${option.name}`}
                             value={positionNames.find((item) => item.id === input.value) || null}
                             onChange={(_event, value) => {
@@ -297,7 +297,9 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
                     <Field name="costcentre">
                       {({ input }) => (
                         <Autocomplete
-                          options={costcentres.filter(isCostCentreActive)}
+                          options={[...costcentres]
+                            .filter(isCostcentreActive)
+                            .sort((a, b) => a.number - b.number)}
                           getOptionLabel={(option) =>
                             `${option.number} ${checkCostCentreActiveStatus(option, t('edit_position.not_active_suffix'))}`
                           }

--- a/frontend/src/components/Table/VirkarekisteriTable.tsx
+++ b/frontend/src/components/Table/VirkarekisteriTable.tsx
@@ -270,31 +270,31 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
       // Sama kuin yllä, mutta katsotaan virkaan asettamispäivää päättyen
       let matchesStartDateEnding = true;
       if (startDateEndsSearch) {
-        if (!position.employeeEndDate && !position.replacementEndDate) {
+        if (!position.employeeStartDate && !position.replacementStartDate) {
           matchesStartDateEnding = false;
         } else if (employeeNameSearch && position.employeeName && replacementNameSearch && position.replacementName) {
           if (
-            position.employeeEndDate &&
-            position.replacementEndDate &&
-            parseDate(position.employeeEndDate) > parseDate(startDateEndsSearch) &&
-            parseDate(position.replacementEndDate) > parseDate(startDateEndsSearch)
+            position.employeeStartDate &&
+            position.replacementStartDate &&
+            parseDate(position.employeeStartDate) > parseDate(startDateEndsSearch) &&
+            parseDate(position.replacementStartDate) > parseDate(startDateEndsSearch)
           ) {
             matchesStartDateEnding = false;
           }
-        } else if (employeeNameSearch && position.employeeName && position.employeeEndDate) {
-          if (parseDate(position.employeeEndDate) > parseDate(startDateEndsSearch)) {
+        } else if (employeeNameSearch && position.employeeName && position.employeeStartDate) {
+          if (parseDate(position.employeeStartDate) > parseDate(startDateEndsSearch)) {
             matchesStartDateEnding = false;
           }
-        } else if (replacementNameSearch && position.replacementName && position.replacementEndDate) {
-          if (parseDate(position.replacementEndDate) > parseDate(startDateEndsSearch)) {
+        } else if (replacementNameSearch && position.replacementName && position.replacementStartDate) {
+          if (parseDate(position.replacementStartDate) > parseDate(startDateEndsSearch)) {
             matchesStartDateEnding = false;
           }
-        } else if (position.employeeName && position.employeeEndDate) {
-          if (parseDate(position.employeeEndDate) > parseDate(startDateEndsSearch)) {
+        } else if (position.employeeName && position.employeeStartDate) {
+          if (parseDate(position.employeeStartDate) > parseDate(startDateEndsSearch)) {
             matchesStartDateEnding = false;
           }
-        } else if (position.replacementName && position.replacementEndDate) {
-          if (parseDate(position.replacementEndDate) > parseDate(startDateEndsSearch)) {
+        } else if (position.replacementName && position.replacementStartDate) {
+          if (parseDate(position.replacementStartDate) > parseDate(startDateEndsSearch)) {
             matchesStartDateEnding = false;
           }
         }


### PR DESCRIPTION
- Position start date ends search now works properly
- Subject admin panel search is no longer case sensitive
- Admin panel tables are in discussed default orders and stay like that (when searching or filtering) until sorted otherwise
- All costcentre and position name dropdown menus are in discussed orders (when creating, modifying or making mass changes)
- Insert script typo fixed

![image](https://github.com/user-attachments/assets/509570c5-12ff-407e-bce7-e4c297f26872)
![image](https://github.com/user-attachments/assets/d229e4f7-64f4-4afd-8fb1-4e9e63e16c88)
![image](https://github.com/user-attachments/assets/012ee195-5681-4a5e-b835-20466ec68dfc)

