### PR TITLE
Task/134 selection of authorized position name for position

### DIFF
--- a/frontend/src/components/Modal/CreateVirkaModal.tsx
+++ b/frontend/src/components/Modal/CreateVirkaModal.tsx
@@ -37,6 +37,7 @@ import { useCreatePositionMutation } from 'redux/api-slices/functions/positions-
 import { useState } from 'react';
 import { useEffect } from 'react';
 import { checkCostCentreActiveStatus } from 'utils/checkCostCentreActiveStatus';
+import { isDateRangeActive } from 'utils/isDateRangeActive';
 
 interface CreateVirkaModalProps {
   open: boolean;
@@ -103,16 +104,6 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
       return t('error.vacancy_size_error');
     }
     return undefined;
-  };
-
-  const isCostcentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-
-    const validFrom = costCentre.validFrom ? new Date(costCentre.validFrom) : null;
-    const validUntil = costCentre.validUntil ? new Date(costCentre.validUntil) : null;
-
-    return (!validFrom || validFrom <= today) && (!validUntil || validUntil >= today);
   };
 
   useEffect(() => {
@@ -307,7 +298,9 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
                       {({ input }) => (
                         <Autocomplete
                           {...input}
-                          options={[...costcentres].filter(isCostcentreActive).sort((a, b) => a.number - b.number)}
+                          options={[...costcentres]
+                            .filter(cc => isDateRangeActive(cc.validFrom, cc.validUntil))
+                            .sort((a, b) => a.number - b.number)}
                           loading={costcentresLoading}
                           getOptionLabel={(option) =>
                             option

--- a/frontend/src/components/Modal/CreateVirkaModal.tsx
+++ b/frontend/src/components/Modal/CreateVirkaModal.tsx
@@ -189,7 +189,9 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
                     <Field name="positionNameId">
                       {({ input }) => (
                         <Autocomplete
-                          options={[...positionNames].sort((a, b) => a.name.localeCompare(b.name, 'fi'))}
+                          options={[...positionNames]
+                            .filter((pn) => isDateRangeActive(pn.validFrom, pn.validUntil))
+                            .sort((a, b) => a.name.localeCompare(b.name, 'fi'))}
                           loading={positionNamesLoading}
                           getOptionLabel={(option) => option.name}
                           value={input.value || null}

--- a/frontend/src/components/Modal/CreateVirkaModal.tsx
+++ b/frontend/src/components/Modal/CreateVirkaModal.tsx
@@ -301,7 +301,7 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
                         <Autocomplete
                           {...input}
                           options={[...costcentres]
-                            .filter(cc => isDateRangeActive(cc.validFrom, cc.validUntil))
+                            .filter((cc) => isDateRangeActive(cc.validFrom, cc.validUntil))
                             .sort((a, b) => a.number - b.number)}
                           loading={costcentresLoading}
                           getOptionLabel={(option) =>

--- a/frontend/src/components/Modal/MassChangesModal.tsx
+++ b/frontend/src/components/Modal/MassChangesModal.tsx
@@ -175,6 +175,7 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
                             options={
                               selectedOption === 'positionNameId'
                                 ? [...positionNames]
+                                    .filter((pn) => isDateRangeActive(pn.validFrom, pn.validUntil))
                                     .sort((a, b) => a.name.localeCompare(b.name, 'fi'))
                                     .map((tree) => ({
                                       id: tree.id,

--- a/frontend/src/components/Modal/MassChangesModal.tsx
+++ b/frontend/src/components/Modal/MassChangesModal.tsx
@@ -8,7 +8,7 @@ import { useGetCostCentersQuery } from 'redux/api-slices/functions/costcentre-ap
 import { skipToken } from '@reduxjs/toolkit/query';
 import type { Position } from 'models/Position';
 import { useUpdatePositionMutation } from 'redux/api-slices/functions/positions-api';
-
+import { isDateRangeActive } from 'utils/isDateRangeActive';
 interface MassChangesModalProps {
   open: boolean;
   handleClose: () => void;
@@ -37,19 +37,6 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
   const { data: costcentres = [], isLoading: costcentresLoading } = useGetCostCentersQuery(
     open ? undefined : skipToken,
   );
-
-  const isCostcentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-
-    const validFrom = costCentre.validFrom ? new Date(costCentre.validFrom) : null;
-    const validUntil = costCentre.validUntil ? new Date(costCentre.validUntil) : null;
-
-    if (validFrom) validFrom.setHours(0, 0, 0, 0);
-    if (validUntil) validUntil.setHours(0, 0, 0, 0);
-
-    return (!validFrom || validFrom <= today) && (!validUntil || validUntil >= today);
-  };
 
   const [updatePosition] = useUpdatePositionMutation();
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
@@ -194,7 +181,7 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
                                       label: `${tree.name}`,
                                     }))
                                 : [...costcentres]
-                                    .filter(isCostcentreActive)
+                                    .filter(cc => isDateRangeActive(cc.validFrom, cc.validUntil))
                                     .sort((a, b) => a.number - b.number)
                                     .map((tree) => ({
                                       id: tree.id,

--- a/frontend/src/components/Modal/MassChangesModal.tsx
+++ b/frontend/src/components/Modal/MassChangesModal.tsx
@@ -182,7 +182,7 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
                                       label: `${tree.name}`,
                                     }))
                                 : [...costcentres]
-                                    .filter(cc => isDateRangeActive(cc.validFrom, cc.validUntil))
+                                    .filter((cc) => isDateRangeActive(cc.validFrom, cc.validUntil))
                                     .sort((a, b) => a.number - b.number)
                                     .map((tree) => ({
                                       id: tree.id,

--- a/frontend/src/components/Modal/ModifyVirkaModal.tsx
+++ b/frontend/src/components/Modal/ModifyVirkaModal.tsx
@@ -31,6 +31,7 @@ import { useGetCostCentersQuery } from 'redux/api-slices/functions/costcentre-ap
 import { useEffect, useState } from 'react';
 import { useGetTeacherSubjectsQuery } from 'redux/api-slices/functions/teachersubject-api';
 import { skipToken } from '@reduxjs/toolkit/query';
+import { isDateRangeActive } from 'utils/isDateRangeActive';
 
 interface ModifyVirkaModalProps {
   open: boolean;
@@ -140,16 +141,6 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
       return t('error.vacancy_fill_greater_than_size');
     }
     return undefined;
-  };
-
-  const isCostcentreActive = (costCentre: { validFrom?: string; validUntil?: string }): boolean => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-
-    const validFrom = costCentre.validFrom ? new Date(costCentre.validFrom) : null;
-    const validUntil = costCentre.validUntil ? new Date(costCentre.validUntil) : null;
-
-    return (!validFrom || validFrom <= today) && (!validUntil || validUntil >= today);
   };
 
   const onSubmit = async (values: FormValues) => {
@@ -297,7 +288,9 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
                     <Field name="costcentre">
                       {({ input }) => (
                         <Autocomplete
-                          options={[...costcentres].filter(isCostcentreActive).sort((a, b) => a.number - b.number)}
+                          options={[...costcentres]
+                            .filter(cc => isDateRangeActive(cc.validFrom, cc.validUntil))
+                            .sort((a, b) => a.number - b.number)}
                           getOptionLabel={(option) =>
                             `${option.number} ${checkCostCentreActiveStatus(option, t('edit_position.not_active_suffix'))}`
                           }

--- a/frontend/src/components/Modal/ModifyVirkaModal.tsx
+++ b/frontend/src/components/Modal/ModifyVirkaModal.tsx
@@ -291,7 +291,7 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
                       {({ input }) => (
                         <Autocomplete
                           options={[...costcentres]
-                            .filter(cc => isDateRangeActive(cc.validFrom, cc.validUntil))
+                            .filter((cc) => isDateRangeActive(cc.validFrom, cc.validUntil))
                             .sort((a, b) => a.number - b.number)}
                           getOptionLabel={(option) =>
                             `${option.number} ${checkCostCentreActiveStatus(option, t('edit_position.not_active_suffix'))}`

--- a/frontend/src/components/Modal/ModifyVirkaModal.tsx
+++ b/frontend/src/components/Modal/ModifyVirkaModal.tsx
@@ -252,7 +252,9 @@ const ModifyVirkaModal: React.FC<ModifyVirkaModalProps> = ({ open, handleClose, 
                       <Field name="positionName">
                         {({ input }) => (
                           <Autocomplete
-                            options={[...positionNames].sort((a, b) => a.name.localeCompare(b.name, 'fi'))}
+                            options={[...positionNames]
+                              .filter((pn) => isDateRangeActive(pn.validFrom, pn.validUntil))
+                              .sort((a, b) => a.name.localeCompare(b.name, 'fi'))}
                             getOptionLabel={(option) => `${option.name}`}
                             value={positionNames.find((item) => item.id === input.value) || null}
                             onChange={(_event, value) => {

--- a/frontend/src/models/PositionName.ts
+++ b/frontend/src/models/PositionName.ts
@@ -1,4 +1,6 @@
 export interface PositionName {
   id: string;
   name: string;
+  validFrom?: string;
+  validUntil?: string;
 }

--- a/frontend/src/utils/isDateRangeActive.ts
+++ b/frontend/src/utils/isDateRangeActive.ts
@@ -1,12 +1,9 @@
-export const isDateRangeActive = (
-    validFrom?: string, 
-    validUntil?: string
-) : boolean => {
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
+export const isDateRangeActive = (validFrom?: string, validUntil?: string): boolean => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
 
-    const fromDate = validFrom ? new Date(validFrom) : null;
-    const untilDate = validUntil ? new Date(validUntil) : null;
+  const fromDate = validFrom ? new Date(validFrom) : null;
+  const untilDate = validUntil ? new Date(validUntil) : null;
 
-    return (!fromDate || fromDate <= today) && (!untilDate || untilDate >= today);
-}
+  return (!fromDate || fromDate <= today) && (!untilDate || untilDate >= today);
+};

--- a/frontend/src/utils/isDateRangeActive.ts
+++ b/frontend/src/utils/isDateRangeActive.ts
@@ -1,0 +1,12 @@
+export const isDateRangeActive = (
+    validFrom?: string, 
+    validUntil?: string
+) : boolean => {
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    const fromDate = validFrom ? new Date(validFrom) : null;
+    const untilDate = validUntil ? new Date(validUntil) : null;
+
+    return (!fromDate || fromDate <= today) && (!untilDate || untilDate >= today);
+}


### PR DESCRIPTION
- Only show active position names when creating a new position or modifying one (or multiple with mass changes)
- A single utils function checks activeness of position names and also costcentres (so costcentre dropdowns should also be tested)

To test with non active position names, running a script like this is helpful: (these shouldn't be active anymore or for a while)
![image](https://github.com/user-attachments/assets/3c565a08-7180-4345-9536-8e73eeabbcdc)

Costcentres can be created from the control panel, so doing the same there is helpful to check the same for their dropdowns.