### PR TITLE
(#173) Non active subjects to position search dropdown

### DIFF
--- a/frontend/src/components/Table/VirkarekisteriTable.tsx
+++ b/frontend/src/components/Table/VirkarekisteriTable.tsx
@@ -70,11 +70,6 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
   const [lazyEmployeeTrigger] = useLazyGetPositionEmployeeQuery();
   const { data: subjects = [] } = useGetTeacherSubjectsQuery();
 
-  // Filteröi aktiiviset aineet
-  const activeSubjectNames = subjects
-    .filter((subject) => subject.active === true)
-    .map((subject) => subject.subjectName);
-
   // Suodatuskentät (Hakusuodattimet)
   const [vacancyNumberSearch, setVacancyNumberSearch] = useState('');
   const [placementLocationStateSearch, setPlacementLocationStateSearch] = useState('');
@@ -713,12 +708,19 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
                         },
                       }}
                     >
-                      {activeSubjectNames.sort().map((subject) => (
-                        <MenuItem key={subject} value={subject}>
-                          <Checkbox checked={teacherSubjectSearch.includes(subject)} />
-                          <ListItemText primary={subject} />
-                        </MenuItem>
-                      ))}
+                      {subjects
+                        .slice()
+                        .sort((a, b) => a.subjectName.localeCompare(b.subjectName, 'fi'))
+                        .map((subject) => {
+                          const value = subject.subjectName;
+                          const label = checkSubjectActiveStatus(subject, t('table.not_active_suffix'));
+                          return (
+                            <MenuItem key={value} value={value}>
+                              <Checkbox checked={teacherSubjectSearch.includes(value)} />
+                              <ListItemText primary={label} />
+                            </MenuItem>
+                          );
+                        })}
                     </Select>
                   </FormControl>
                 </Grid2>


### PR DESCRIPTION
- When searching for teacher positions, the subjects dropdown menu now includes also non active subjects with the "not active" suffix

![image](https://github.com/user-attachments/assets/8ee24b4a-88db-4ec9-9dab-ba402f95c718)
