### PR TITLE
(#153) (#176) (#175) CSV import support and bug fixes

### DIFF
--- a/backend/Virkarekisteri/src/Functions/Positions/CreatePositionsFromCsv.cs
+++ b/backend/Virkarekisteri/src/Functions/Positions/CreatePositionsFromCsv.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Logging;
 using Virkarekisteri.Middleware.Attributes;
 using Virkarekisteri.Models;
 using Virkarekisteri.Repositories;
+using System.Text;
 
 namespace Virkarekisteri.Functions.Positions;
 
@@ -47,11 +48,16 @@ public class CreatePositionsFromCsv(
 
         int totalLines = 0;
 
-        using (var reader = new StreamReader(file.OpenReadStream()))
+        // Register code page provider for non-UTF8 encodings (Windows-1252 for Excel CSV) so it supports letters like "ä", "ö" 
+        Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        using (var reader = new StreamReader(file.OpenReadStream(), Encoding.GetEncoding(1252)))
         {
             // Skip the header line
             var headerLine = await reader.ReadLineAsync();
             int lineNumber = 2;
+
+            // Expected date formats d.M.yyyy or dd.MM.yyyy 
+            var dateFormats = new[] { "d.M.yyyy", "dd.MM.yyyy" };
 
             while (!reader.EndOfStream)
             {
@@ -66,37 +72,47 @@ public class CreatePositionsFromCsv(
 
                 try
                 {
-                    var position = new Position { CreationDecisionNumber = values[3] };
+                    var position = new Position { CreationDecisionNumber = values[4] };
 
                     if (string.IsNullOrWhiteSpace(position.CreationDecisionNumber))
                     {
                         throw new Exception("Päätösnumero on pakollinen eikä se voi olla tyhjä.");
                     }
 
-                    if (
-                        string.IsNullOrWhiteSpace(values[2])
-                        || !DateTime.TryParse(
-                            values[2],
-                            CultureInfo.InvariantCulture,
-                            DateTimeStyles.None,
-                            out var createdAt
-                        )
-                    )
+                    // Parse CreatedAt in dd.MM.yyyy
+                    if (string.IsNullOrWhiteSpace(values[3])
+                        || !DateTime.TryParseExact(values[3], dateFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var createdAt))
                     {
-                        throw new Exception(
-                            "Perustamisajankohta on pakollinen ja sen on oltava kelvollinen päivämäärä."
-                        );
+                        throw new Exception("Perustamisajankohta on pakollinen ja sen on oltava muodossa dd.MM.yyyy.");
                     }
                     position.CreatedAt = createdAt;
 
-                    if (string.IsNullOrWhiteSpace(values[4]) || !int.TryParse(values[4], out var type))
+                    // Parse Type (Laji) as numeric or textual
+                    var typeText = values[8]?.Trim();
+                    if (string.IsNullOrWhiteSpace(typeText))
+                        throw new Exception("Laji on pakollinen ja sen on oltava kelvollinen kokonaisluku tai tekstiarvo.");
+                    int type;
+                    if (!int.TryParse(typeText, out type))
                     {
-                        throw new Exception("Laji on pakollinen ja sen on oltava kelvollinen kokonaisluku.");
+                        // support textual values mapping to numeric codes
+                        switch (typeText.ToLowerInvariant())
+                        {
+                            case "virka":
+                            case "position":
+                                type = 1;
+                                break;
+                            case "toimi":
+                            case "post":
+                                type = 2;
+                                break;
+                            default:
+                                throw new Exception("Laji on pakollinen ja sen on oltava kelvollinen kokonaisluku tai yksi seuraavista teksteistä: Virka, Toimi, Position, Post.");
+                        }
                     }
                     position.Type = type;
 
                     // Handle costcentre from CSV
-                    var costcentreNumber = values[0];
+                    var costcentreNumber = values[1];
                     var costcentreId = await positionRepository.GetCostcentreIdByNumber(costcentreNumber);
                     if (costcentreId == Guid.Empty)
                     {
@@ -119,7 +135,7 @@ public class CreatePositionsFromCsv(
                     position.CostcentreId = costcentre.Id;
 
                     // Handle position name from CSV
-                    var positionNameName = values[1];
+                    var positionNameName = values[0];
                     var positionNameId = await positionNameRepository.GetPositionNameIdByName(positionNameName);
                     if (positionNameId == Guid.Empty || !positionNameId.HasValue)
                     {
@@ -140,33 +156,34 @@ public class CreatePositionsFromCsv(
                     }
                     position.PositionNameId = positionName.Id;
 
-                    position.EndedAt = string.IsNullOrWhiteSpace(values[5])
-                        ? (DateTime?)null
-                        : DateTime.Parse(values[5], CultureInfo.InvariantCulture);
-                    // Set VacancyStatus = 1 if no end date or end date is in the future
-                    if (!position.EndedAt.HasValue || position.EndedAt.Value.Date > DateTime.Now.Date)
+                    // Parse EndedAt and EndingDecisionNumber together
+                    var endedAtText = values[13]?.Trim();
+                    var endingDecText = values[14]?.Trim();
+                    bool hasEnded = !string.IsNullOrWhiteSpace(endedAtText);
+                    bool hasEndingDec = !string.IsNullOrWhiteSpace(endingDecText);
+                    if (hasEnded ^ hasEndingDec)
                     {
-                        position.VacancyStatus = 1; // 1 = Established
+                        throw new Exception("Viran lakkautus päivämäärä ja lakkautus päätösnumero on annettava molemmat.");
                     }
-                    else
-                    {
-                        position.VacancyStatus = 0; // 0 = Abolished
-                    }
+                    position.EndedAt = hasEnded
+                        ? DateTime.ParseExact(endedAtText, dateFormats, CultureInfo.InvariantCulture, DateTimeStyles.None)
+                        : (DateTime?)null;
 
-                    position.EndingDecisionNumber = string.IsNullOrWhiteSpace(values[6]) ? null : values[6];
-                    position.VacancySize = string.IsNullOrWhiteSpace(values[7])
-                        ? (decimal?)null
-                        : decimal.Parse(values[7], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture);
-                    position.VacancyFill = string.IsNullOrWhiteSpace(values[8])
-                        ? (decimal?)null
-                        : decimal.Parse(values[8], NumberStyles.AllowDecimalPoint, CultureInfo.InvariantCulture);
-                    position.PricingId = string.IsNullOrWhiteSpace(values[9]) ? null : values[9];
+                    // Set VacancyStatus = 1 if no end date or end date is in the future
+                    position.VacancyStatus = !position.EndedAt.HasValue || position.EndedAt.Value.Date > now.Date
+                        ? 1
+                        : 0;
+
+                    position.EndingDecisionNumber = hasEndingDec ? endingDecText : null;
+                    position.VacancySize = NormalizePercent(values[5]);
+                    position.VacancyFill = NormalizePercent(values[6]);
+                    position.PricingId = string.IsNullOrWhiteSpace(values[7]) ? null : values[7];
                     position.EducationLevel = string.IsNullOrWhiteSpace(values[10]) ? null : values[10];
                     position.WorkExperience = string.IsNullOrWhiteSpace(values[11]) ? null : values[11];
                     position.Details = string.IsNullOrWhiteSpace(values[12]) ? null : values[12];
-                    position.PlacementLocation = string.IsNullOrWhiteSpace(values[13]) ? null : values[13];
+                    position.PlacementLocation = string.IsNullOrWhiteSpace(values[2]) ? null : values[2];
 
-                    var teacherSubjectsRaw = values[14];
+                    var teacherSubjectsRaw = values[9];
                     if (!string.IsNullOrWhiteSpace(teacherSubjectsRaw))
                     {
                         var splittedSubjects = teacherSubjectsRaw.Split(',', StringSplitOptions.RemoveEmptyEntries);
@@ -244,5 +261,18 @@ public class CreatePositionsFromCsv(
         };
 
         return new OkObjectResult(response);
+    }
+    private static decimal? NormalizePercent(string s)
+    {
+        if (string.IsNullOrWhiteSpace(s)) return null;
+        var trimmed = s.Trim();
+        bool hasPercent = trimmed.EndsWith("%");
+        var numText = hasPercent
+            ? trimmed.Substring(0, trimmed.Length - 1).Trim()
+            : trimmed;
+        var raw = decimal.Parse(numText, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite, CultureInfo.InvariantCulture);
+        if (hasPercent)
+            return raw / 100m;
+        return raw > 1m ? raw / 100m : raw;
     }
 }

--- a/backend/Virkarekisteri/src/Functions/Positions/CreatePositionsFromCsv.cs
+++ b/backend/Virkarekisteri/src/Functions/Positions/CreatePositionsFromCsv.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using System.Text;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
@@ -6,7 +7,6 @@ using Microsoft.Extensions.Logging;
 using Virkarekisteri.Middleware.Attributes;
 using Virkarekisteri.Models;
 using Virkarekisteri.Repositories;
-using System.Text;
 
 namespace Virkarekisteri.Functions.Positions;
 
@@ -48,7 +48,7 @@ public class CreatePositionsFromCsv(
 
         int totalLines = 0;
 
-        // Register code page provider for non-UTF8 encodings (Windows-1252 for Excel CSV) so it supports letters like "ä", "ö" 
+        // Register code page provider for non-UTF8 encodings (Windows-1252 for Excel CSV) so it supports letters like "ä", "ö"
         Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         using (var reader = new StreamReader(file.OpenReadStream(), Encoding.GetEncoding(1252)))
         {
@@ -56,7 +56,7 @@ public class CreatePositionsFromCsv(
             var headerLine = await reader.ReadLineAsync();
             int lineNumber = 2;
 
-            // Expected date formats d.M.yyyy or dd.MM.yyyy 
+            // Expected date formats d.M.yyyy or dd.MM.yyyy
             var dateFormats = new[] { "d.M.yyyy", "dd.MM.yyyy" };
 
             while (!reader.EndOfStream)
@@ -80,8 +80,16 @@ public class CreatePositionsFromCsv(
                     }
 
                     // Parse CreatedAt in dd.MM.yyyy
-                    if (string.IsNullOrWhiteSpace(values[3])
-                        || !DateTime.TryParseExact(values[3], dateFormats, CultureInfo.InvariantCulture, DateTimeStyles.None, out var createdAt))
+                    if (
+                        string.IsNullOrWhiteSpace(values[3])
+                        || !DateTime.TryParseExact(
+                            values[3],
+                            dateFormats,
+                            CultureInfo.InvariantCulture,
+                            DateTimeStyles.None,
+                            out var createdAt
+                        )
+                    )
                     {
                         throw new Exception("Perustamisajankohta on pakollinen ja sen on oltava muodossa dd.MM.yyyy.");
                     }
@@ -90,7 +98,9 @@ public class CreatePositionsFromCsv(
                     // Parse Type (Laji) as numeric or textual
                     var typeText = values[8]?.Trim();
                     if (string.IsNullOrWhiteSpace(typeText))
-                        throw new Exception("Laji on pakollinen ja sen on oltava kelvollinen kokonaisluku tai tekstiarvo.");
+                        throw new Exception(
+                            "Laji on pakollinen ja sen on oltava kelvollinen kokonaisluku tai tekstiarvo."
+                        );
                     int type;
                     if (!int.TryParse(typeText, out type))
                     {
@@ -106,7 +116,9 @@ public class CreatePositionsFromCsv(
                                 type = 2;
                                 break;
                             default:
-                                throw new Exception("Laji on pakollinen ja sen on oltava kelvollinen kokonaisluku tai yksi seuraavista teksteistä: Virka, Toimi, Position, Post.");
+                                throw new Exception(
+                                    "Laji on pakollinen ja sen on oltava kelvollinen kokonaisluku tai yksi seuraavista teksteistä: Virka, Toimi, Position, Post."
+                                );
                         }
                     }
                     position.Type = type;
@@ -163,16 +175,22 @@ public class CreatePositionsFromCsv(
                     bool hasEndingDec = !string.IsNullOrWhiteSpace(endingDecText);
                     if (hasEnded ^ hasEndingDec)
                     {
-                        throw new Exception("Viran lakkautus päivämäärä ja lakkautus päätösnumero on annettava molemmat.");
+                        throw new Exception(
+                            "Viran lakkautus päivämäärä ja lakkautus päätösnumero on annettava molemmat."
+                        );
                     }
                     position.EndedAt = hasEnded
-                        ? DateTime.ParseExact(endedAtText, dateFormats, CultureInfo.InvariantCulture, DateTimeStyles.None)
+                        ? DateTime.ParseExact(
+                            endedAtText,
+                            dateFormats,
+                            CultureInfo.InvariantCulture,
+                            DateTimeStyles.None
+                        )
                         : (DateTime?)null;
 
                     // Set VacancyStatus = 1 if no end date or end date is in the future
-                    position.VacancyStatus = !position.EndedAt.HasValue || position.EndedAt.Value.Date > now.Date
-                        ? 1
-                        : 0;
+                    position.VacancyStatus =
+                        !position.EndedAt.HasValue || position.EndedAt.Value.Date > now.Date ? 1 : 0;
 
                     position.EndingDecisionNumber = hasEndingDec ? endingDecText : null;
                     position.VacancySize = NormalizePercent(values[5]);
@@ -262,15 +280,19 @@ public class CreatePositionsFromCsv(
 
         return new OkObjectResult(response);
     }
+
     private static decimal? NormalizePercent(string s)
     {
-        if (string.IsNullOrWhiteSpace(s)) return null;
+        if (string.IsNullOrWhiteSpace(s))
+            return null;
         var trimmed = s.Trim();
         bool hasPercent = trimmed.EndsWith("%");
-        var numText = hasPercent
-            ? trimmed.Substring(0, trimmed.Length - 1).Trim()
-            : trimmed;
-        var raw = decimal.Parse(numText, NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite, CultureInfo.InvariantCulture);
+        var numText = hasPercent ? trimmed.Substring(0, trimmed.Length - 1).Trim() : trimmed;
+        var raw = decimal.Parse(
+            numText,
+            NumberStyles.AllowDecimalPoint | NumberStyles.AllowLeadingWhite | NumberStyles.AllowTrailingWhite,
+            CultureInfo.InvariantCulture
+        );
         if (hasPercent)
             return raw / 100m;
         return raw > 1m ? raw / 100m : raw;

--- a/frontend/public/locales/en/translation.json
+++ b/frontend/public/locales/en/translation.json
@@ -22,7 +22,7 @@
   },
   "create_csv_position": {
     "success": " positions imported successfully.",
-    "error1": "There were ",
+    "error1": "No positions were created. There were ",
     "error2": " errors in the CSV file.",
     "upload": "Upload",
     "title": "Create positions from CSV",
@@ -79,7 +79,15 @@
     "subjects": "Subjects",
     "not_active_suffix": "not active",
     "yes": "Yes",
-    "no": "No"
+    "no": "No",
+    "columns": "Columns",
+    "columns_label": "Show/hide columns",
+    "density": "Row density",
+    "density_label": "Row density",
+    "density_compact": "Compact",
+    "density_standard": "Standard",
+    "density_comfortable": "Comfortable",
+    "select": "Mass change checkbox"
   },
   "tabs": {
     "positions": "Positions list",

--- a/frontend/public/locales/fi/translation.json
+++ b/frontend/public/locales/fi/translation.json
@@ -22,7 +22,7 @@
   },
   "create_csv_position": {
     "success": " virkaa luotu onnistuneesti.",
-    "error1": "CSV-tiedostossa oli ",
+    "error1": "Virkoja ei luotu. CSV-tiedostossa oli ",
     "error2": " virheellistä riviä.",
     "upload": "Lataa",
     "title": "Luo virkoja CSV-tiedostosta",
@@ -59,7 +59,7 @@
   "table": {
     "created_at": "Perustamisajankohta",
     "ended_at": "Viran lakkautus päivämäärä",
-    "creation_decision_number": "Päätösnumero",
+    "creation_decision_number": "Luonti päätösnumero",
     "ending_decision_number": "Lakkautus päätösnumero",
     "type": "Laji",
     "vacancy_number": "Vakanssinumero",
@@ -79,7 +79,15 @@
     "subjects": "Opetettavat aineet",
     "not_active_suffix": "ei aktiivinen",
     "yes": "Kyllä",
-    "no": "Ei"
+    "no": "Ei",
+    "columns": "Sarakkeet",
+    "columns_label": "Näytä/piilota sarakkeet",
+    "density": "Rivien tiheys",
+    "density_label": "Rivien tiheyden asetus",
+    "density_compact": "Tiivis",
+    "density_standard": "Vakio",
+    "density_comfortable": "Mukava",
+    "select": "Massamuutos valintaruutu"
   },
   "tabs": {
     "positions": "Virkalistaus",

--- a/frontend/public/locales/sv/translation.json
+++ b/frontend/public/locales/sv/translation.json
@@ -79,7 +79,15 @@
     "subjects": "",
     "not_active_suffix": "",
     "yes": "",
-    "no": ""
+    "no": "",
+    "columns": "",
+    "columns_label": "",
+    "density": "",
+    "density_label": "",
+    "density_compact": "",
+    "density_standard": "",
+    "density_comfortable": "",
+    "select": ""
   },
   "tabs": {
     "positions": "",

--- a/frontend/src/components/Details/BasicDetails.tsx
+++ b/frontend/src/components/Details/BasicDetails.tsx
@@ -13,6 +13,7 @@ import { useGetTeacherSubjectsQuery } from 'redux/api-slices/functions/teachersu
 import { checkSubjectActiveStatus } from 'utils/checkSubjectActiveStatus';
 import { checkCostCentreActiveStatus } from 'utils/checkCostCentreActiveStatus';
 import { useGetPositionNameByIdQuery } from 'redux/api-slices/functions/position-names-api';
+import { format } from 'date-fns';
 
 interface BasicDetailsProps {
   position: Position;
@@ -231,6 +232,15 @@ const BasicDetails: React.FC<BasicDetailsProps> = ({ position }) => {
               <RenderReadonlyTextField value={teacherSubjects.join(', ')} />
             </Grid2>
           )}
+          <Grid2 size={4} px={2}>
+            <Typography component="div" sx={{ color: '#7f7f7f' }}>
+              {t('table.created_at')}
+            </Typography>
+
+            <RenderReadonlyTextField
+              value={position.createdAt ? format(new Date(position.createdAt), 'dd.MM.yyyy') : ''}
+            />
+          </Grid2>
         </Grid2>
 
         <Accordion sx={{ mt: 2, mb: 4 }}>

--- a/frontend/src/components/Modal/CreateVirkaModal.tsx
+++ b/frontend/src/components/Modal/CreateVirkaModal.tsx
@@ -38,6 +38,7 @@ import { useState } from 'react';
 import { useEffect } from 'react';
 import { checkCostCentreActiveStatus } from 'utils/checkCostCentreActiveStatus';
 import { isDateRangeActive } from 'utils/isDateRangeActive';
+import { format } from 'date-fns';
 
 interface CreateVirkaModalProps {
   open: boolean;
@@ -212,7 +213,7 @@ const CreateVirkaModal: React.FC<CreateVirkaModalProps> = ({ open, handleClose }
                   </Grid2>
 
                   <Grid2 size={4}>
-                    <Field name="createdAt">
+                    <Field name="createdAt" initialValue={format(new Date(), 'yyyy-MM-dd')}>
                       {({ input }) => (
                         <TextField
                           {...input}

--- a/frontend/src/components/Modal/MassChangesModal.tsx
+++ b/frontend/src/components/Modal/MassChangesModal.tsx
@@ -66,6 +66,7 @@ const MassChangesModal: React.FC<MassChangesModalProps> = ({ open, handleClose, 
           type: position.type,
           decisionNumber: values.decisionNumber,
           isTeacher: position.isTeacher,
+          subjectIds: position.subjectIds,
         };
 
         // Override the specific field with the new value

--- a/frontend/src/components/Table/VirkarekisteriTable.tsx
+++ b/frontend/src/components/Table/VirkarekisteriTable.tsx
@@ -95,7 +95,8 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
   const [enrichedPositions, setEnrichedPositions] = useState<Position[]>([]);
 
   // Valitut rivit
-  const [, setSelectedRows] = useState<Position[]>([]);
+  const [selectedRows, setSelectedRows] = useState<Position[]>([]);
+  const [clickedRowId, setClickedRowId] = useState<string | null>(null);
 
   // Density vaihtoehdot ja localStorageen
   const [density, setDensity] = React.useState<GridDensity>(() => {
@@ -818,7 +819,7 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
       </Box>
 
       {/* DataGrid-komponentti */}
-      <Box sx={{ mt: 2, width: '100%', height: 'auto' }}>
+      <Box sx={{ mt: 2, width: '100%', maxHeight: 1000, display: 'flex', flexDirection: 'column' }}>
         <DataGrid
           loading={loading}
           rows={filteredData}
@@ -834,22 +835,29 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
           }}
           pageSizeOptions={[10, 30, 50, 100]}
           checkboxSelection
+          isRowSelectable={(params) => params.row.vacancyStatus !== 0}
+          disableRowSelectionOnClick
           onRowSelectionModelChange={(newSelection) => {
-            const selection = newSelection as string[];
-            const newSelectedRows = filteredData.filter((row) => selection.includes(row.id ?? row.costcentreId!));
-            setSelectedRows(newSelectedRows);
-            onRowSelectionChange(newSelectedRows);
-
-            if (newSelectedRows.length > 0) {
-              const lastSelectedRow = newSelectedRows[newSelectedRows.length - 1];
-              const rowId = lastSelectedRow.id ?? lastSelectedRow.costcentreId;
-              if (rowId) {
-                getPosition(rowId, true);
-                dispatch(selectPosition(rowId));
-              }
-            } else {
+            const sel = (newSelection as string[]).map((id) => filteredData.find((r) => r.id === id)!).filter(Boolean);
+            setSelectedRows(sel);
+            onRowSelectionChange(sel);
+          }}
+          onRowClick={(params) => {
+            const id = params.id as string;
+            if (clickedRowId === id) {
+              setClickedRowId(null);
               dispatch(clearSelectedPosition());
+            } else {
+              setClickedRowId(id);
+              getPosition(id, true);
+              dispatch(selectPosition(id));
             }
+          }}
+          getRowClassName={(params) => (params.id === clickedRowId ? 'clicked-row' : '')}
+          sx={{
+            '& .clicked-row .MuiDataGrid-cell': {
+              backgroundColor: (theme) => theme.palette.primary.light + '40',
+            },
           }}
           rowCount={filteredData.length}
           paginationMode="client"
@@ -860,6 +868,9 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
             localStorage.setItem('columnVisibilityModel', JSON.stringify(newModel));
           }}
           slotProps={{
+            pagination: {
+              labelRowsPerPage: t('table.rows_per_page'),
+            },
             toolbar: {
               csvOptions: {
                 fileName: 'Virkarekisteri_data_table',
@@ -871,21 +882,32 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
                 hideToolbar: true,
                 includeCheckboxes: false,
                 pageStyle: `
-          @page {
-            size: landscape;
-            margin: 10mm;
-          }
-          @media print {
-            .MuiDataGrid-root {
-              transform: scale(0.7);
-              transform-origin: top left;
+            @page {
+              size: landscape;
+              margin: 10mm;
             }
-          }
-        `,
+            @media print {
+              .MuiDataGrid-root {
+                transform: scale(0.7);
+                transform-origin: top left;
+              }
+            }
+          `,
               },
             },
           }}
           slots={{ toolbar: GridToolbar }}
+          localeText={{
+            // toolbar texts
+            toolbarColumns: t('table.columns'),
+            toolbarColumnsLabel: t('table.columns_label'),
+            toolbarDensity: t('table.density'),
+            toolbarDensityLabel: t('table.density_label'),
+            toolbarDensityCompact: t('table.density_compact'),
+            toolbarDensityStandard: t('table.density_standard'),
+            toolbarDensityComfortable: t('table.density_comfortable'),
+            checkboxSelectionHeaderName: t('table.select'),
+          }}
         />
       </Box>
     </>

--- a/frontend/src/components/Table/VirkarekisteriTable.tsx
+++ b/frontend/src/components/Table/VirkarekisteriTable.tsx
@@ -95,7 +95,7 @@ const DataTable: React.FC<DataTableProps> = ({ onRowSelectionChange }) => {
   const [enrichedPositions, setEnrichedPositions] = useState<Position[]>([]);
 
   // Valitut rivit
-  const [selectedRows, setSelectedRows] = useState<Position[]>([]);
+  const [, setSelectedRows] = useState<Position[]>([]);
   const [clickedRowId, setClickedRowId] = useState<string | null>(null);
 
   // Density vaihtoehdot ja localStorageen


### PR DESCRIPTION
(#153) (#176) (#175) CSV import support and bug fixes

* CSV import
  - Align field names/formatting with table columns
  - Provide Excel-compatible template and handle non-UTF8 (äöå) encodings
  - Validate pairing of creation date+decision and ending date+decision number
  - Accept varied date formats (e.g. 6.5.2025 or 06.05.2025), type/value inputs (Virka/Laji, 1/2, Position/Post), and size formats (55%, “55 %”, 0.5)
  - Now should support Excel usage for CSV file!
* Datagrid and UI enhancements
  - Add Finnish/English translations for pagination and column labels
  - Auto-scale to a sensible max-height. Long list was bad UX
  - Toggle row selection on click and integrate mass changes to checkboxes

* Basic details
  - Show creation date (fixed off-by-one bug) as this was already
    supported in Position but never used...

* Critical bug fixes
  - Prevent mass changes module from resetting subjects on abolished positions
  - (#158) Prevent mass changes checkbox for abolished positions as those were possible to be edited which should not be possible