### PR TITLE
Task/162 fix tests for costcentres number length check

### DIFF
--- a/backend/Virkarekisteri.Tests/src/Positions/CreatePositionTests.cs
+++ b/backend/Virkarekisteri.Tests/src/Positions/CreatePositionTests.cs
@@ -16,6 +16,7 @@ public class CreatePositionTests
     private readonly Mock<IPositionRepository> _positionRepositoryMock;
     private readonly Mock<IPositionNameRepository> _positionNameRepositoryMock;
     private readonly Mock<IPositionChangeLogRepository> _positionChangeLogRepositoryMock;
+    private readonly Mock<ICostcentreRepository> _costcentreRepositoryMock;
     private readonly CreatePosition _function;
 
     public CreatePositionTests()
@@ -24,6 +25,7 @@ public class CreatePositionTests
         _positionRepositoryMock = new Mock<IPositionRepository>();
         _positionNameRepositoryMock = new Mock<IPositionNameRepository>();
         _positionChangeLogRepositoryMock = new Mock<IPositionChangeLogRepository>();
+        _costcentreRepositoryMock = new Mock<ICostcentreRepository>();
 
         _function = new CreatePosition(
             loggerMock.Object,
@@ -80,7 +82,9 @@ public class CreatePositionTests
             PositionNameId = Guid.NewGuid(),
             CostcentreId = Guid.NewGuid(),
         };
+
         _positionRepositoryMock.Setup(repo => repo.CreatePosition(It.IsAny<Position>())).ReturnsAsync(mockPosition);
+        _positionRepositoryMock.Setup(repo => repo.GetCostcentreNumberById(It.IsAny<Guid>())).ReturnsAsync("1234");
 
         var json = JsonSerializer.Serialize(mockPosition);
         var jsonBytes = Encoding.UTF8.GetBytes(json);
@@ -107,7 +111,7 @@ public class CreatePositionTests
             CreationDecisionNumber = "123",
             Type = 0,
             PositionNameId = mockPositionNameId,
-            PositionName = new PositionName { Id = mockPositionNameId, Name = "Test" },
+            //PositionName = new PositionName { Id = mockPositionNameId, Name = "Test" },
             CostcentreId = Guid.NewGuid(),
         };
 
@@ -115,6 +119,7 @@ public class CreatePositionTests
         _positionNameRepositoryMock
             .Setup(repo => repo.GetPositionNameIdByName(It.IsAny<string>()))
             .ReturnsAsync(mockPositionNameId);
+        _positionRepositoryMock.Setup(repo => repo.GetCostcentreNumberById(It.IsAny<Guid>())).ReturnsAsync("1234");
 
         var json = JsonSerializer.Serialize(mockPosition);
         var jsonBytes = Encoding.UTF8.GetBytes(json);

--- a/backend/Virkarekisteri/src/Functions/Positions/CreatePosition.cs
+++ b/backend/Virkarekisteri/src/Functions/Positions/CreatePosition.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.Logging;
+using Microsoft.IdentityModel.Tokens;
 using Virkarekisteri.Middleware.Attributes;
 using Virkarekisteri.Models;
 using Virkarekisteri.Repositories;

--- a/database/scripts/PostDeployment.sql
+++ b/database/scripts/PostDeployment.sql
@@ -10,7 +10,7 @@
 
 -- Insert test data to Costcentres table
 --PRINT 'INSERTING DATA TO Costcentres TABLE';
---:r .\Inserts\Constcentres.sql
+--:r .\Inserts\Costcentres.sql
 
 -- Insert test data to Position table
 --PRINT 'INSERTING DATA TO Positions TABLE';


### PR DESCRIPTION
(#162)

Noticed two small bugs related to costcentres:
* Backend tests failed for position creation, as the length of the costcentre's number cannot be checked. Added a mocked dependecy of repository for this.
* Fixed a typo in the costcentre.sql import 